### PR TITLE
Enhance trending card visuals

### DIFF
--- a/src/components/trending/TrendingCard.jsx
+++ b/src/components/trending/TrendingCard.jsx
@@ -30,11 +30,11 @@ const TrendingCard = ({ product }) => {
           <p className="text-gray-600 text-sm text-end">{product.category}</p>
         </div>
       </div>
-      <div className="flex justify-center items-center w-full h-full">
+      <div className="flex justify-center items-center w-full h-full rounded-md bg-gradient-to-br from-white to-gray-200">
         <img
           src={product.image}
           alt={product.name}
-          className="w-32 h-20 xs:w-28 xs:h-16 sm:w-32 sm:h-20 py-2 object-cover hover:scale-110 transition"
+          className="w-32 h-20 xs:w-28 xs:h-16 sm:w-32 sm:h-20 py-2 object-contain hover:scale-110 transition"
         />
       </div>
     </Link>


### PR DESCRIPTION
## Summary
- give trending product image container a subtle gradient background
- ensure the eyewear images scale cleanly using `object-contain`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685aa79ea0e0832287165af2280adf57