### PR TITLE
Restructure admin panel with sidebar navigation

### DIFF
--- a/src/pages/AdminCategories.jsx
+++ b/src/pages/AdminCategories.jsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+import { adminAddCategoryService, adminDeleteCategoryService } from "../api/apiServices";
+import { useAdminContext, useProductsContext } from "../contexts";
+
+const AdminCategories = () => {
+  const { token } = useAdminContext();
+  const { categoryList } = useProductsContext();
+  const [categoryForm, setCategoryForm] = useState({
+    _id: "",
+    categoryName: "",
+    description: "",
+    categoryImg: "",
+  });
+
+  const addCategory = async (e) => {
+    e.preventDefault();
+    await adminAddCategoryService(categoryForm, token);
+    setCategoryForm({ _id: "", categoryName: "", description: "", categoryImg: "" });
+  };
+
+  const deleteCategory = async (id) => {
+    await adminDeleteCategoryService(id, token);
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <h2 className="text-2xl font-semibold">Управление категориями</h2>
+      <div className="grid md:grid-cols-2 gap-8">
+        <form onSubmit={addCategory} className="flex flex-col gap-2">
+          <input
+            type="text"
+            placeholder="ID"
+            className="border p-2 rounded"
+            value={categoryForm._id}
+            onChange={(e) => setCategoryForm({ ...categoryForm, _id: e.target.value })}
+          />
+          <input
+            type="text"
+            placeholder="Название"
+            className="border p-2 rounded"
+            value={categoryForm.categoryName}
+            onChange={(e) => setCategoryForm({ ...categoryForm, categoryName: e.target.value })}
+          />
+          <input
+            type="text"
+            placeholder="Описание"
+            className="border p-2 rounded"
+            value={categoryForm.description}
+            onChange={(e) => setCategoryForm({ ...categoryForm, description: e.target.value })}
+          />
+          <input
+            type="text"
+            placeholder="URL изображения"
+            className="border p-2 rounded"
+            value={categoryForm.categoryImg}
+            onChange={(e) => setCategoryForm({ ...categoryForm, categoryImg: e.target.value })}
+          />
+          <button className="btn-primary mt-2">Добавить</button>
+        </form>
+        <ul className="flex flex-col gap-2">
+          {categoryList.map((c) => (
+            <li key={c._id} className="border p-2 rounded flex justify-between">
+              <span>{c.categoryName}</span>
+              <button className="text-red-600" onClick={() => deleteCategory(c._id)}>
+                Удалить
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default AdminCategories;

--- a/src/pages/AdminHome.jsx
+++ b/src/pages/AdminHome.jsx
@@ -1,0 +1,23 @@
+import { useProductsContext } from "../contexts";
+
+const AdminHome = () => {
+  const { allProducts, categoryList } = useProductsContext();
+
+  return (
+    <div className="flex flex-col gap-6">
+      <h2 className="text-2xl font-semibold">Статистика</h2>
+      <div className="grid md:grid-cols-2 gap-4">
+        <div className="p-4 bg-white rounded shadow">
+          <span className="text-gray-600">Всего товаров:</span>
+          <p className="text-3xl font-bold">{allProducts.length}</p>
+        </div>
+        <div className="p-4 bg-white rounded shadow">
+          <span className="text-gray-600">Всего категорий:</span>
+          <p className="text-3xl font-bold">{categoryList.length}</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AdminHome;

--- a/src/pages/AdminProducts.jsx
+++ b/src/pages/AdminProducts.jsx
@@ -1,0 +1,107 @@
+import { useState } from "react";
+import { adminAddProductService, adminDeleteProductService } from "../api/apiServices";
+import { useAdminContext, useProductsContext } from "../contexts";
+
+const AdminProducts = () => {
+  const { token } = useAdminContext();
+  const { allProducts } = useProductsContext();
+  const [productForm, setProductForm] = useState({
+    _id: "",
+    name: "",
+    price: 0,
+    newPrice: 0,
+    brand: "",
+    category: "",
+    image: "",
+  });
+
+  const addProduct = async (e) => {
+    e.preventDefault();
+    await adminAddProductService(productForm, token);
+    setProductForm({
+      _id: "",
+      name: "",
+      price: 0,
+      newPrice: 0,
+      brand: "",
+      category: "",
+      image: "",
+    });
+  };
+
+  const deleteProduct = async (id) => {
+    await adminDeleteProductService(id, token);
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <h2 className="text-2xl font-semibold">Управление товарами</h2>
+      <div className="grid md:grid-cols-2 gap-8">
+        <form onSubmit={addProduct} className="flex flex-col gap-2">
+          <input
+            type="text"
+            placeholder="ID"
+            className="border p-2 rounded"
+            value={productForm._id}
+            onChange={(e) => setProductForm({ ...productForm, _id: e.target.value })}
+          />
+          <input
+            type="text"
+            placeholder="Название"
+            className="border p-2 rounded"
+            value={productForm.name}
+            onChange={(e) => setProductForm({ ...productForm, name: e.target.value })}
+          />
+          <input
+            type="number"
+            placeholder="Цена"
+            className="border p-2 rounded"
+            value={productForm.price}
+            onChange={(e) => setProductForm({ ...productForm, price: Number(e.target.value) })}
+          />
+          <input
+            type="number"
+            placeholder="Новая цена"
+            className="border p-2 rounded"
+            value={productForm.newPrice}
+            onChange={(e) => setProductForm({ ...productForm, newPrice: Number(e.target.value) })}
+          />
+          <input
+            type="text"
+            placeholder="Бренд"
+            className="border p-2 rounded"
+            value={productForm.brand}
+            onChange={(e) => setProductForm({ ...productForm, brand: e.target.value })}
+          />
+          <input
+            type="text"
+            placeholder="Категория"
+            className="border p-2 rounded"
+            value={productForm.category}
+            onChange={(e) => setProductForm({ ...productForm, category: e.target.value })}
+          />
+          <input
+            type="text"
+            placeholder="URL изображения"
+            className="border p-2 rounded"
+            value={productForm.image}
+            onChange={(e) => setProductForm({ ...productForm, image: e.target.value })}
+          />
+          <button className="btn-primary mt-2">Добавить</button>
+        </form>
+        <ul className="flex flex-col gap-2">
+          {allProducts.map((p) => (
+            <li key={p._id} className="border p-2 rounded flex justify-between">
+              <span>{p.name}</span>
+              <button className="text-red-600" onClick={() => deleteProduct(p._id)}>
+                Удалить
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default AdminProducts;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -13,6 +13,8 @@ export { default as Profile } from "./Profile";
 export { default as Checkout } from "./Checkout";
 export { default as Orders } from "./Orders";
 export { default as AdminLogin } from "./AdminLogin";
-export { default as AdminDashboard } from "./AdminDashboard";
+export { default as AdminHome } from "./AdminHome";
+export { default as AdminProducts } from "./AdminProducts";
+export { default as AdminCategories } from "./AdminCategories";
 
 export { default as ErrorPage } from "./ErrorPage";

--- a/src/routes/AdminLayout.jsx
+++ b/src/routes/AdminLayout.jsx
@@ -1,0 +1,42 @@
+import { NavLink, Outlet } from "react-router-dom";
+import { useAdminContext } from "../contexts";
+
+const links = [
+  { path: "/admin", label: "Статистика" },
+  { path: "/admin/products", label: "Товары" },
+  { path: "/admin/categories", label: "Категории" },
+];
+
+const AdminLayout = () => {
+  const { logout } = useAdminContext();
+
+  return (
+    <div className="min-h-screen flex">
+      <aside className="w-64 bg-gray-800 text-gray-100 p-6 flex flex-col gap-4">
+        <h1 className="text-2xl font-bold mb-4">Админ панель</h1>
+        <nav className="flex flex-col gap-2 flex-1">
+          {links.map(({ path, label }) => (
+            <NavLink
+              key={path}
+              to={path}
+              end={path === "/admin"}
+              className={({ isActive }) =>
+                `p-2 rounded hover:bg-gray-700 ${isActive ? "bg-gray-700" : ""}`
+              }
+            >
+              {label}
+            </NavLink>
+          ))}
+        </nav>
+        <button onClick={logout} className="btn-secondary mt-auto">
+          Выйти
+        </button>
+      </aside>
+      <main className="flex-1 p-6 bg-[--theme-color]">
+        <Outlet />
+      </main>
+    </div>
+  );
+};
+
+export default AdminLayout;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -5,7 +5,16 @@ import RequiresAuth from "./RequiresAuth";
 import { authRoutes, contentRoutes } from "./publicRoutes";
 import { privateRoutes } from "./privateRoutes";
 
-import { ErrorPage, Home, Login, AdminLogin, AdminDashboard } from "../pages";
+import {
+  ErrorPage,
+  Home,
+  Login,
+  AdminLogin,
+  AdminHome,
+  AdminProducts,
+  AdminCategories,
+} from "../pages";
+import AdminLayout from "./AdminLayout";
 import { useAuthContext, useAdminContext } from "../contexts";
 
 const Index = () => {
@@ -32,9 +41,11 @@ const Index = () => {
         ))}
       </Route>
       <Route
-        element={adminToken ? <Outlet /> : <Navigate to="/admin/login" replace />}
+        element={adminToken ? <AdminLayout /> : <Navigate to="/admin/login" replace />}
       >
-        <Route path="/admin" element={<AdminDashboard />} />
+        <Route path="/admin" element={<AdminHome />} index />
+        <Route path="/admin/products" element={<AdminProducts />} />
+        <Route path="/admin/categories" element={<AdminCategories />} />
       </Route>
       <Route path="/admin/login" element={<AdminLogin />} />
       <Route element={<SharedLayout />}>


### PR DESCRIPTION
## Summary
- create dedicated AdminLayout with sidebar menu
- add AdminHome page with basic statistics
- add AdminProducts page to manage products
- add AdminCategories page to manage categories
- configure routes to use new admin layout

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_685af9ea2b988322b62dece1fa909fb4