### PR TITLE
Add pagination and required admin form fields

### DIFF
--- a/src/components/Pagination.jsx
+++ b/src/components/Pagination.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+const Pagination = ({ currentPage, totalItems, itemsPerPage, onPageChange }) => {
+  const totalPages = Math.ceil(totalItems / itemsPerPage);
+  if (totalPages <= 1) return null;
+  const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
+  return (
+    <div className="flex gap-2 mt-4 flex-wrap">
+      {pages.map((page) => (
+        <button
+          key={page}
+          className={`px-3 py-1 border rounded ${
+            page === currentPage ? "bg-blue-500 text-white" : ""
+          }`}
+          onClick={() => onPageChange(page)}
+        >
+          {page}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default Pagination;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -19,3 +19,4 @@ export { default as AddressCard } from "./address/AddressCard";
 export { default as AddressForm } from "./address/AddressForm";
 
 export { default as Loader } from "./loader/Loader";
+export { default as Pagination } from "./Pagination";

--- a/src/pages/AdminBrands.jsx
+++ b/src/pages/AdminBrands.jsx
@@ -6,6 +6,7 @@ import {
   adminUpdateBrandService,
 } from "../api/apiServices";
 import { useAdminContext, useProductsContext } from "../contexts";
+import { Pagination } from "../components";
 import { v4 as uuid } from "uuid";
 
 const AdminBrands = () => {
@@ -14,6 +15,8 @@ const AdminBrands = () => {
   const getNewBrand = () => ({ _id: uuid(), brandName: "" });
   const [brandForm, setBrandForm] = useState(getNewBrand());
   const [isEditing, setIsEditing] = useState(false);
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 10;
 
   const saveBrand = async (e) => {
     e.preventDefault();
@@ -24,11 +27,13 @@ const AdminBrands = () => {
     }
     setBrandForm(getNewBrand());
     setIsEditing(false);
+    setCurrentPage(1);
     refreshBrands();
   };
 
   const deleteBrand = async (id) => {
     await adminDeleteBrandService(id, token);
+    setCurrentPage(1);
     refreshBrands();
   };
 
@@ -46,6 +51,9 @@ const AdminBrands = () => {
     refreshBrands();
   }, []);
 
+  const startIndex = (currentPage - 1) * itemsPerPage;
+  const displayedBrands = brandList.slice(startIndex, startIndex + itemsPerPage);
+
   return (
     <div className="flex flex-col gap-6">
       <h2 className="text-2xl font-semibold">Бренды</h2>
@@ -57,6 +65,7 @@ const AdminBrands = () => {
             className="border p-2 rounded"
             value={brandForm._id}
             onChange={(e) => setBrandForm({ ...brandForm, _id: e.target.value })}
+            required
           />
           <label className="text-sm">Название</label>
           <input
@@ -64,6 +73,7 @@ const AdminBrands = () => {
             className="border p-2 rounded"
             value={brandForm.brandName}
             onChange={(e) => setBrandForm({ ...brandForm, brandName: e.target.value })}
+            required
           />
           <div className="flex gap-2 mt-2">
             <button className="btn-primary" type="submit">
@@ -77,7 +87,7 @@ const AdminBrands = () => {
           </div>
         </form>
         <ul className="flex flex-col gap-2">
-          {brandList.map((b) => (
+          {displayedBrands.map((b) => (
             <li key={b._id} className="border p-2 rounded flex justify-between">
               <span>{b.brandName}</span>
               <div className="flex gap-2">
@@ -91,6 +101,12 @@ const AdminBrands = () => {
             </li>
           ))}
         </ul>
+        <Pagination
+          currentPage={currentPage}
+          totalItems={brandList.length}
+          itemsPerPage={itemsPerPage}
+          onPageChange={setCurrentPage}
+        />
       </div>
     </div>
   );

--- a/src/pages/AdminCategories.jsx
+++ b/src/pages/AdminCategories.jsx
@@ -7,6 +7,7 @@ import {
   adminUpdateCategoryService,
 } from "../api/apiServices";
 import { useAdminContext, useProductsContext } from "../contexts";
+import { Pagination } from "../components";
 
 const AdminCategories = () => {
   const { token } = useAdminContext();
@@ -19,6 +20,8 @@ const AdminCategories = () => {
   });
   const [categoryForm, setCategoryForm] = useState(getNewCategory());
   const [isEditing, setIsEditing] = useState(false);
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 10;
 
   const handleImageChange = (e) => {
     const file = e.target.files[0];
@@ -40,11 +43,13 @@ const AdminCategories = () => {
     }
     setCategoryForm(getNewCategory());
     setIsEditing(false);
+    setCurrentPage(1);
     refreshCategories();
   };
 
   const deleteCategory = async (id) => {
     await adminDeleteCategoryService(id, token);
+    setCurrentPage(1);
     refreshCategories();
   };
 
@@ -58,6 +63,12 @@ const AdminCategories = () => {
     setIsEditing(false);
   };
 
+  const startIndex = (currentPage - 1) * itemsPerPage;
+  const displayedCategories = categoryList.slice(
+    startIndex,
+    startIndex + itemsPerPage
+  );
+
   return (
     <div className="flex flex-col gap-6">
       <h2 className="text-2xl font-semibold">Управление категориями</h2>
@@ -69,6 +80,7 @@ const AdminCategories = () => {
             className="border p-2 rounded"
             value={categoryForm._id}
             onChange={(e) => setCategoryForm({ ...categoryForm, _id: e.target.value })}
+            required
           />
           <label className="text-sm">Название</label>
           <input
@@ -76,6 +88,7 @@ const AdminCategories = () => {
             className="border p-2 rounded"
             value={categoryForm.categoryName}
             onChange={(e) => setCategoryForm({ ...categoryForm, categoryName: e.target.value })}
+            required
           />
           <label className="text-sm">Описание</label>
           <input
@@ -83,6 +96,7 @@ const AdminCategories = () => {
             className="border p-2 rounded"
             value={categoryForm.description}
             onChange={(e) => setCategoryForm({ ...categoryForm, description: e.target.value })}
+            required
           />
           <label className="text-sm">Изображение</label>
           <label className="file-label">
@@ -92,6 +106,7 @@ const AdminCategories = () => {
               accept="image/*"
               className="file-input"
               onChange={handleImageChange}
+              required
             />
           </label>
           {categoryForm.categoryImg && (
@@ -109,7 +124,7 @@ const AdminCategories = () => {
           </div>
         </form>
         <ul className="flex flex-col gap-2">
-          {categoryList.map((c) => (
+          {displayedCategories.map((c) => (
             <li key={c._id} className="border p-2 rounded flex justify-between">
               <span>{c.categoryName}</span>
               <div className="flex gap-2">
@@ -123,6 +138,12 @@ const AdminCategories = () => {
             </li>
           ))}
         </ul>
+        <Pagination
+          currentPage={currentPage}
+          totalItems={categoryList.length}
+          itemsPerPage={itemsPerPage}
+          onPageChange={setCurrentPage}
+        />
       </div>
     </div>
   );

--- a/src/pages/AdminDashboard.jsx
+++ b/src/pages/AdminDashboard.jsx
@@ -6,6 +6,7 @@ import {
   adminDeleteCategoryService,
 } from "../api/apiServices";
 import { useAdminContext, useProductsContext } from "../contexts";
+import { Pagination } from "../components";
 import { useNavigate } from "react-router";
 
 const AdminDashboard = () => {
@@ -28,6 +29,9 @@ const AdminDashboard = () => {
     description: "",
     categoryImg: "",
   });
+  const [currentProductPage, setCurrentProductPage] = useState(1);
+  const [currentCategoryPage, setCurrentCategoryPage] = useState(1);
+  const itemsPerPage = 10;
 
   useEffect(() => {
     if (!token) {
@@ -47,21 +51,30 @@ const AdminDashboard = () => {
       category: "",
       image: "",
     });
+    setCurrentProductPage(1);
   };
 
   const addCategory = async (e) => {
     e.preventDefault();
     await adminAddCategoryService(categoryForm, token);
     setCategoryForm({ _id: "", categoryName: "", description: "", categoryImg: "" });
+    setCurrentCategoryPage(1);
   };
 
   const deleteProduct = async (id) => {
     await adminDeleteProductService(id, token);
+    setCurrentProductPage(1);
   };
 
   const deleteCategory = async (id) => {
     await adminDeleteCategoryService(id, token);
+    setCurrentCategoryPage(1);
   };
+
+  const productStart = (currentProductPage - 1) * itemsPerPage;
+  const displayedProducts = allProducts.slice(productStart, productStart + itemsPerPage);
+  const categoryStart = (currentCategoryPage - 1) * itemsPerPage;
+  const displayedCategories = categoryList.slice(categoryStart, categoryStart + itemsPerPage);
 
   return (
     <div className="p-6 flex flex-col gap-8">
@@ -81,6 +94,7 @@ const AdminDashboard = () => {
               className="border p-2 rounded"
               value={productForm._id}
               onChange={(e) => setProductForm({ ...productForm, _id: e.target.value })}
+              required
             />
             <input
               type="text"
@@ -88,6 +102,7 @@ const AdminDashboard = () => {
               className="border p-2 rounded"
               value={productForm.name}
               onChange={(e) => setProductForm({ ...productForm, name: e.target.value })}
+              required
             />
             <input
               type="number"
@@ -95,6 +110,7 @@ const AdminDashboard = () => {
               className="border p-2 rounded"
               value={productForm.price}
               onChange={(e) => setProductForm({ ...productForm, price: Number(e.target.value) })}
+              required
             />
             <input
               type="number"
@@ -102,6 +118,7 @@ const AdminDashboard = () => {
               className="border p-2 rounded"
               value={productForm.newPrice}
               onChange={(e) => setProductForm({ ...productForm, newPrice: Number(e.target.value) })}
+              required
             />
             <input
               type="text"
@@ -109,6 +126,7 @@ const AdminDashboard = () => {
               className="border p-2 rounded"
               value={productForm.brand}
               onChange={(e) => setProductForm({ ...productForm, brand: e.target.value })}
+              required
             />
             <input
               type="text"
@@ -116,6 +134,7 @@ const AdminDashboard = () => {
               className="border p-2 rounded"
               value={productForm.category}
               onChange={(e) => setProductForm({ ...productForm, category: e.target.value })}
+              required
             />
             <input
               type="text"
@@ -123,6 +142,7 @@ const AdminDashboard = () => {
               className="border p-2 rounded"
               value={productForm.image}
               onChange={(e) => setProductForm({ ...productForm, image: e.target.value })}
+              required
             />
             <button className="btn-primary mt-2">Добавить</button>
           </form>
@@ -136,6 +156,7 @@ const AdminDashboard = () => {
               className="border p-2 rounded"
               value={categoryForm._id}
               onChange={(e) => setCategoryForm({ ...categoryForm, _id: e.target.value })}
+              required
             />
             <input
               type="text"
@@ -143,6 +164,7 @@ const AdminDashboard = () => {
               className="border p-2 rounded"
               value={categoryForm.categoryName}
               onChange={(e) => setCategoryForm({ ...categoryForm, categoryName: e.target.value })}
+              required
             />
             <input
               type="text"
@@ -150,6 +172,7 @@ const AdminDashboard = () => {
               className="border p-2 rounded"
               value={categoryForm.description}
               onChange={(e) => setCategoryForm({ ...categoryForm, description: e.target.value })}
+              required
             />
             <input
               type="text"
@@ -157,6 +180,7 @@ const AdminDashboard = () => {
               className="border p-2 rounded"
               value={categoryForm.categoryImg}
               onChange={(e) => setCategoryForm({ ...categoryForm, categoryImg: e.target.value })}
+              required
             />
             <button className="btn-primary mt-2">Добавить</button>
           </form>
@@ -165,7 +189,7 @@ const AdminDashboard = () => {
       <section>
         <h2 className="text-xl font-semibold mb-2">Товары</h2>
         <ul className="flex flex-col gap-2">
-          {allProducts.map((p) => (
+          {displayedProducts.map((p) => (
             <li key={p._id} className="border p-2 rounded flex justify-between">
               <span>{p.name}</span>
               <button className="text-red-600" onClick={() => deleteProduct(p._id)}>
@@ -174,11 +198,17 @@ const AdminDashboard = () => {
             </li>
           ))}
         </ul>
+        <Pagination
+          currentPage={currentProductPage}
+          totalItems={allProducts.length}
+          itemsPerPage={itemsPerPage}
+          onPageChange={setCurrentProductPage}
+        />
       </section>
       <section>
         <h2 className="text-xl font-semibold mb-2">Категории</h2>
         <ul className="flex flex-col gap-2">
-          {categoryList.map((c) => (
+          {displayedCategories.map((c) => (
             <li key={c._id} className="border p-2 rounded flex justify-between">
               <span>{c.categoryName}</span>
               <button className="text-red-600" onClick={() => deleteCategory(c._id)}>
@@ -187,6 +217,12 @@ const AdminDashboard = () => {
             </li>
           ))}
         </ul>
+        <Pagination
+          currentPage={currentCategoryPage}
+          totalItems={categoryList.length}
+          itemsPerPage={itemsPerPage}
+          onPageChange={setCurrentCategoryPage}
+        />
       </section>
     </div>
   );

--- a/src/pages/AdminLogin.jsx
+++ b/src/pages/AdminLogin.jsx
@@ -32,6 +32,7 @@ const AdminLogin = () => {
                 onChange={(e) =>
                   setCredentials({ ...credentials, username: e.target.value })
                 }
+                required
               />
             </label>
             <label className="flex flex-col">
@@ -43,6 +44,7 @@ const AdminLogin = () => {
                 onChange={(e) =>
                   setCredentials({ ...credentials, password: e.target.value })
                 }
+                required
               />
             </label>
             <button

--- a/src/pages/AdminProducts.jsx
+++ b/src/pages/AdminProducts.jsx
@@ -7,6 +7,7 @@ import {
   adminUpdateProductService,
 } from "../api/apiServices";
 import { useAdminContext, useProductsContext } from "../contexts";
+import { Pagination } from "../components";
 import { gendersList } from "../utils/constants";
 
 const AdminProducts = () => {
@@ -29,6 +30,8 @@ const AdminProducts = () => {
   });
   const [productForm, setProductForm] = useState(getNewProduct());
   const [isEditing, setIsEditing] = useState(false);
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 10;
 
   const handleImageChange = (e) => {
     const file = e.target.files[0];
@@ -50,11 +53,13 @@ const AdminProducts = () => {
     }
     setProductForm(getNewProduct());
     setIsEditing(false);
+    setCurrentPage(1);
     refreshProducts();
   };
 
   const deleteProduct = async (id) => {
     await adminDeleteProductService(id, token);
+    setCurrentPage(1);
     refreshProducts();
   };
 
@@ -67,6 +72,9 @@ const AdminProducts = () => {
     setProductForm(getNewProduct());
     setIsEditing(false);
   };
+
+  const startIndex = (currentPage - 1) * itemsPerPage;
+  const displayedProducts = allProducts.slice(startIndex, startIndex + itemsPerPage);
 
   return (
     <div className="flex flex-col gap-6">
@@ -82,6 +90,7 @@ const AdminProducts = () => {
             className="border p-2 rounded"
             value={productForm._id}
             onChange={(e) => setProductForm({ ...productForm, _id: e.target.value })}
+            required
           />
           <label className="text-sm">Название</label>
           <input
@@ -89,12 +98,14 @@ const AdminProducts = () => {
             className="border p-2 rounded"
             value={productForm.name}
             onChange={(e) => setProductForm({ ...productForm, name: e.target.value })}
+            required
           />
           <label className="text-sm">Описание</label>
           <textarea
             className="border p-2 rounded"
             value={productForm.description}
             onChange={(e) => setProductForm({ ...productForm, description: e.target.value })}
+            required
           />
           <label className="text-sm">Цена</label>
           <input
@@ -103,6 +114,7 @@ const AdminProducts = () => {
             value={productForm.price}
             min={0}
             onChange={(e) => setProductForm({ ...productForm, price: Number(e.target.value) })}
+            required
           />
           <label className="text-sm">Новая цена</label>
           <input
@@ -111,12 +123,14 @@ const AdminProducts = () => {
             value={productForm.newPrice}
             min={0}
             onChange={(e) => setProductForm({ ...productForm, newPrice: Number(e.target.value) })}
+            required
           />
           <label className="text-sm">Бренд</label>
           <select
             className="border p-2 rounded"
             value={productForm.brand}
             onChange={(e) => setProductForm({ ...productForm, brand: e.target.value })}
+            required
           >
             <option value="">Выберите бренд</option>
             {brandList.map((b) => (
@@ -130,6 +144,7 @@ const AdminProducts = () => {
             className="border p-2 rounded"
             value={productForm.category}
             onChange={(e) => setProductForm({ ...productForm, category: e.target.value })}
+            required
           >
             <option value="">Выберите категорию</option>
             {categoryList.map((c) => (
@@ -143,6 +158,7 @@ const AdminProducts = () => {
             className="border p-2 rounded"
             value={productForm.gender}
             onChange={(e) => setProductForm({ ...productForm, gender: e.target.value })}
+            required
           >
             <option value="">Выберите пол</option>
             {gendersList
@@ -159,6 +175,7 @@ const AdminProducts = () => {
             className="border p-2 rounded"
             value={productForm.weight}
             onChange={(e) => setProductForm({ ...productForm, weight: e.target.value })}
+            required
           />
           <label className="text-sm">Количество</label>
           <input
@@ -167,6 +184,7 @@ const AdminProducts = () => {
             value={productForm.quantity}
             min={0}
             onChange={(e) => setProductForm({ ...productForm, quantity: Number(e.target.value) })}
+            required
           />
           <label className="text-sm">Рейтинг</label>
           <input
@@ -177,6 +195,7 @@ const AdminProducts = () => {
             min={0}
             max={5}
             onChange={(e) => setProductForm({ ...productForm, rating: Number(e.target.value) })}
+            required
           />
           <label className="inline-flex items-center gap-2">
             <input
@@ -195,6 +214,7 @@ const AdminProducts = () => {
               accept="image/*"
               className="file-input"
               onChange={handleImageChange}
+              required
             />
           </label>
           {productForm.image && (
@@ -212,7 +232,7 @@ const AdminProducts = () => {
           </div>
         </form>
         <ul className="flex flex-col gap-2">
-          {allProducts.map((p) => (
+          {displayedProducts.map((p) => (
             <li key={p._id} className="border p-2 rounded flex justify-between">
               <span>{p.name}</span>
               <div className="flex gap-2">
@@ -226,6 +246,12 @@ const AdminProducts = () => {
             </li>
           ))}
         </ul>
+        <Pagination
+          currentPage={currentPage}
+          totalItems={allProducts.length}
+          itemsPerPage={itemsPerPage}
+          onPageChange={setCurrentPage}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add new reusable Pagination component
- mark admin form inputs as required
- paginate admin lists in categories, brands, products and dashboard

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b067584a48322bded13d518ff2da9