### PR TITLE
Improve admin UI forms and pagination

### DIFF
--- a/src/contexts/productsContext/ProductsContext.js
+++ b/src/contexts/productsContext/ProductsContext.js
@@ -1,4 +1,4 @@
-import { createContext, useEffect, useReducer, useState } from "react";
+import { createContext, useEffect, useReducer, useState, useCallback } from "react";
 import { initialState, productsReducer } from "../../reducers/productsReducer";
 import {
   getAllCategoriesService,
@@ -56,7 +56,7 @@ const ProductsContextProvider = ({ children }) => {
     }
   };
 
-  const refreshBrands = async () => {
+  const refreshBrands = useCallback(async () => {
     setLoading(true);
     try {
       const res = await getAllBrandsService();
@@ -71,7 +71,7 @@ const ProductsContextProvider = ({ children }) => {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     setLoading(true);

--- a/src/pages/AdminBrands.jsx
+++ b/src/pages/AdminBrands.jsx
@@ -15,11 +15,13 @@ const AdminBrands = () => {
   const getNewBrand = () => ({ _id: uuid(), brandName: "" });
   const [brandForm, setBrandForm] = useState(getNewBrand());
   const [isEditing, setIsEditing] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 10;
 
   const saveBrand = async (e) => {
     e.preventDefault();
+    setSubmitted(true);
     if (isEditing) {
       await adminUpdateBrandService(brandForm._id, brandForm, token);
     } else {
@@ -28,6 +30,7 @@ const AdminBrands = () => {
     setBrandForm(getNewBrand());
     setIsEditing(false);
     setCurrentPage(1);
+    setSubmitted(false);
     refreshBrands();
   };
 
@@ -49,7 +52,7 @@ const AdminBrands = () => {
 
   useEffect(() => {
     refreshBrands();
-  }, []);
+  }, [refreshBrands]);
 
   const startIndex = (currentPage - 1) * itemsPerPage;
   const displayedBrands = brandList.slice(startIndex, startIndex + itemsPerPage);
@@ -62,7 +65,7 @@ const AdminBrands = () => {
           <label className="text-sm">ID</label>
           <input
             type="text"
-            className="border p-2 rounded"
+            className={`border p-2 rounded ${submitted && !brandForm._id ? "border-red-500" : ""}`}
             value={brandForm._id}
             onChange={(e) => setBrandForm({ ...brandForm, _id: e.target.value })}
             required
@@ -70,7 +73,7 @@ const AdminBrands = () => {
           <label className="text-sm">Название</label>
           <input
             type="text"
-            className="border p-2 rounded"
+            className={`border p-2 rounded ${submitted && !brandForm.brandName ? "border-red-500" : ""}`}
             value={brandForm.brandName}
             onChange={(e) => setBrandForm({ ...brandForm, brandName: e.target.value })}
             required
@@ -86,27 +89,29 @@ const AdminBrands = () => {
             )}
           </div>
         </form>
-        <ul className="flex flex-col gap-2">
-          {displayedBrands.map((b) => (
-            <li key={b._id} className="border p-2 rounded flex justify-between">
-              <span>{b.brandName}</span>
-              <div className="flex gap-2">
-                <button className="text-blue-600" onClick={() => startEdit(b)}>
-                  <FaEdit />
-                </button>
-                <button className="text-red-600" onClick={() => deleteBrand(b._id)}>
-                  <FaTrash />
-                </button>
-              </div>
-            </li>
-          ))}
-        </ul>
-        <Pagination
-          currentPage={currentPage}
-          totalItems={brandList.length}
-          itemsPerPage={itemsPerPage}
-          onPageChange={setCurrentPage}
-        />
+        <div className="flex flex-col gap-2">
+          <ul className="flex flex-col gap-2">
+            {displayedBrands.map((b) => (
+              <li key={b._id} className="border p-2 rounded flex justify-between">
+                <span>{b.brandName}</span>
+                <div className="flex gap-2">
+                  <button className="text-blue-600" onClick={() => startEdit(b)}>
+                    <FaEdit />
+                  </button>
+                  <button className="text-red-600" onClick={() => deleteBrand(b._id)}>
+                    <FaTrash />
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+          <Pagination
+            currentPage={currentPage}
+            totalItems={brandList.length}
+            itemsPerPage={itemsPerPage}
+            onPageChange={setCurrentPage}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/pages/AdminCategories.jsx
+++ b/src/pages/AdminCategories.jsx
@@ -20,6 +20,7 @@ const AdminCategories = () => {
   });
   const [categoryForm, setCategoryForm] = useState(getNewCategory());
   const [isEditing, setIsEditing] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 10;
 
@@ -36,6 +37,7 @@ const AdminCategories = () => {
 
   const saveCategory = async (e) => {
     e.preventDefault();
+    setSubmitted(true);
     if (isEditing) {
       await adminUpdateCategoryService(categoryForm._id, categoryForm, token);
     } else {
@@ -44,6 +46,7 @@ const AdminCategories = () => {
     setCategoryForm(getNewCategory());
     setIsEditing(false);
     setCurrentPage(1);
+    setSubmitted(false);
     refreshCategories();
   };
 
@@ -77,7 +80,7 @@ const AdminCategories = () => {
           <label className="text-sm">ID</label>
           <input
             type="text"
-            className="border p-2 rounded"
+            className={`border p-2 rounded ${submitted && !categoryForm._id ? "border-red-500" : ""}`}
             value={categoryForm._id}
             onChange={(e) => setCategoryForm({ ...categoryForm, _id: e.target.value })}
             required
@@ -85,7 +88,7 @@ const AdminCategories = () => {
           <label className="text-sm">Название</label>
           <input
             type="text"
-            className="border p-2 rounded"
+            className={`border p-2 rounded ${submitted && !categoryForm.categoryName ? "border-red-500" : ""}`}
             value={categoryForm.categoryName}
             onChange={(e) => setCategoryForm({ ...categoryForm, categoryName: e.target.value })}
             required
@@ -93,7 +96,7 @@ const AdminCategories = () => {
           <label className="text-sm">Описание</label>
           <input
             type="text"
-            className="border p-2 rounded"
+            className={`border p-2 rounded ${submitted && !categoryForm.description ? "border-red-500" : ""}`}
             value={categoryForm.description}
             onChange={(e) => setCategoryForm({ ...categoryForm, description: e.target.value })}
             required
@@ -123,27 +126,29 @@ const AdminCategories = () => {
             )}
           </div>
         </form>
-        <ul className="flex flex-col gap-2">
-          {displayedCategories.map((c) => (
-            <li key={c._id} className="border p-2 rounded flex justify-between">
-              <span>{c.categoryName}</span>
-              <div className="flex gap-2">
-                <button className="text-blue-600" onClick={() => startEdit(c)}>
-                  <FaEdit />
-                </button>
-                <button className="text-red-600" onClick={() => deleteCategory(c._id)}>
-                  <FaTrash />
-                </button>
-              </div>
-            </li>
-          ))}
-        </ul>
-        <Pagination
-          currentPage={currentPage}
-          totalItems={categoryList.length}
-          itemsPerPage={itemsPerPage}
-          onPageChange={setCurrentPage}
-        />
+        <div className="flex flex-col gap-2">
+          <ul className="flex flex-col gap-2">
+            {displayedCategories.map((c) => (
+              <li key={c._id} className="border p-2 rounded flex justify-between">
+                <span>{c.categoryName}</span>
+                <div className="flex gap-2">
+                  <button className="text-blue-600" onClick={() => startEdit(c)}>
+                    <FaEdit />
+                  </button>
+                  <button className="text-red-600" onClick={() => deleteCategory(c._id)}>
+                    <FaTrash />
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+          <Pagination
+            currentPage={currentPage}
+            totalItems={categoryList.length}
+            itemsPerPage={itemsPerPage}
+            onPageChange={setCurrentPage}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/pages/AdminDashboard.jsx
+++ b/src/pages/AdminDashboard.jsx
@@ -16,8 +16,8 @@ const AdminDashboard = () => {
   const [productForm, setProductForm] = useState({
     _id: "",
     name: "",
-    price: 0,
-    newPrice: 0,
+    price: "",
+    newPrice: "",
     brand: "",
     category: "",
     image: "",
@@ -41,12 +41,17 @@ const AdminDashboard = () => {
 
   const addProduct = async (e) => {
     e.preventDefault();
-    await adminAddProductService(productForm, token);
+    const productData = {
+      ...productForm,
+      price: Number(productForm.price),
+      newPrice: Number(productForm.newPrice),
+    };
+    await adminAddProductService(productData, token);
     setProductForm({
       _id: "",
       name: "",
-      price: 0,
-      newPrice: 0,
+      price: "",
+      newPrice: "",
       brand: "",
       category: "",
       image: "",
@@ -109,7 +114,7 @@ const AdminDashboard = () => {
               placeholder="Цена"
               className="border p-2 rounded"
               value={productForm.price}
-              onChange={(e) => setProductForm({ ...productForm, price: Number(e.target.value) })}
+              onChange={(e) => setProductForm({ ...productForm, price: e.target.value })}
               required
             />
             <input
@@ -117,7 +122,7 @@ const AdminDashboard = () => {
               placeholder="Новая цена"
               className="border p-2 rounded"
               value={productForm.newPrice}
-              onChange={(e) => setProductForm({ ...productForm, newPrice: Number(e.target.value) })}
+              onChange={(e) => setProductForm({ ...productForm, newPrice: e.target.value })}
               required
             />
             <input

--- a/src/pages/AdminProducts.jsx
+++ b/src/pages/AdminProducts.jsx
@@ -17,19 +17,20 @@ const AdminProducts = () => {
     _id: uuid(),
     name: "",
     description: "",
-    price: 0,
-    newPrice: 0,
+    price: "",
+    newPrice: "",
     brand: "",
     category: "",
     gender: "",
     weight: "",
-    quantity: 0,
-    rating: 0,
+    quantity: "",
+    rating: "",
     trending: false,
     image: "",
   });
   const [productForm, setProductForm] = useState(getNewProduct());
   const [isEditing, setIsEditing] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 10;
 
@@ -46,14 +47,23 @@ const AdminProducts = () => {
 
   const saveProduct = async (e) => {
     e.preventDefault();
+    setSubmitted(true);
+    const productData = {
+      ...productForm,
+      price: Number(productForm.price),
+      newPrice: Number(productForm.newPrice),
+      quantity: Number(productForm.quantity),
+      rating: Number(productForm.rating),
+    };
     if (isEditing) {
-      await adminUpdateProductService(productForm._id, productForm, token);
+      await adminUpdateProductService(productForm._id, productData, token);
     } else {
-      await adminAddProductService(productForm, token);
+      await adminAddProductService(productData, token);
     }
     setProductForm(getNewProduct());
     setIsEditing(false);
     setCurrentPage(1);
+    setSubmitted(false);
     refreshProducts();
   };
 
@@ -95,14 +105,14 @@ const AdminProducts = () => {
           <label className="text-sm">Название</label>
           <input
             type="text"
-            className="border p-2 rounded"
+            className={`border p-2 rounded ${submitted && !productForm.name ? "border-red-500" : ""}`}
             value={productForm.name}
             onChange={(e) => setProductForm({ ...productForm, name: e.target.value })}
             required
           />
           <label className="text-sm">Описание</label>
           <textarea
-            className="border p-2 rounded"
+            className={`border p-2 rounded ${submitted && !productForm.description ? "border-red-500" : ""}`}
             value={productForm.description}
             onChange={(e) => setProductForm({ ...productForm, description: e.target.value })}
             required
@@ -110,24 +120,24 @@ const AdminProducts = () => {
           <label className="text-sm">Цена</label>
           <input
             type="number"
-            className="border p-2 rounded"
+            className={`border p-2 rounded ${submitted && !productForm.price ? "border-red-500" : ""}`}
             value={productForm.price}
             min={0}
-            onChange={(e) => setProductForm({ ...productForm, price: Number(e.target.value) })}
+            onChange={(e) => setProductForm({ ...productForm, price: e.target.value })}
             required
           />
           <label className="text-sm">Новая цена</label>
           <input
             type="number"
-            className="border p-2 rounded"
+            className={`border p-2 rounded ${submitted && !productForm.newPrice ? "border-red-500" : ""}`}
             value={productForm.newPrice}
             min={0}
-            onChange={(e) => setProductForm({ ...productForm, newPrice: Number(e.target.value) })}
+            onChange={(e) => setProductForm({ ...productForm, newPrice: e.target.value })}
             required
           />
           <label className="text-sm">Бренд</label>
           <select
-            className="border p-2 rounded"
+            className={`border p-2 rounded ${submitted && !productForm.brand ? "border-red-500" : ""}`}
             value={productForm.brand}
             onChange={(e) => setProductForm({ ...productForm, brand: e.target.value })}
             required
@@ -141,7 +151,7 @@ const AdminProducts = () => {
           </select>
           <label className="text-sm">Категория</label>
           <select
-            className="border p-2 rounded"
+            className={`border p-2 rounded ${submitted && !productForm.category ? "border-red-500" : ""}`}
             value={productForm.category}
             onChange={(e) => setProductForm({ ...productForm, category: e.target.value })}
             required
@@ -155,7 +165,7 @@ const AdminProducts = () => {
           </select>
           <label className="text-sm">Пол</label>
           <select
-            className="border p-2 rounded"
+            className={`border p-2 rounded ${submitted && !productForm.gender ? "border-red-500" : ""}`}
             value={productForm.gender}
             onChange={(e) => setProductForm({ ...productForm, gender: e.target.value })}
             required
@@ -172,7 +182,7 @@ const AdminProducts = () => {
           <label className="text-sm">Вес</label>
           <input
             type="text"
-            className="border p-2 rounded"
+            className={`border p-2 rounded ${submitted && !productForm.weight ? "border-red-500" : ""}`}
             value={productForm.weight}
             onChange={(e) => setProductForm({ ...productForm, weight: e.target.value })}
             required
@@ -180,21 +190,21 @@ const AdminProducts = () => {
           <label className="text-sm">Количество</label>
           <input
             type="number"
-            className="border p-2 rounded"
+            className={`border p-2 rounded ${submitted && !productForm.quantity ? "border-red-500" : ""}`}
             value={productForm.quantity}
             min={0}
-            onChange={(e) => setProductForm({ ...productForm, quantity: Number(e.target.value) })}
+            onChange={(e) => setProductForm({ ...productForm, quantity: e.target.value })}
             required
           />
           <label className="text-sm">Рейтинг</label>
           <input
             type="number"
-            className="border p-2 rounded"
+            className={`border p-2 rounded ${submitted && !productForm.rating ? "border-red-500" : ""}`}
             value={productForm.rating}
             step="0.1"
             min={0}
             max={5}
-            onChange={(e) => setProductForm({ ...productForm, rating: Number(e.target.value) })}
+            onChange={(e) => setProductForm({ ...productForm, rating: e.target.value })}
             required
           />
           <label className="inline-flex items-center gap-2">
@@ -231,27 +241,29 @@ const AdminProducts = () => {
             )}
           </div>
         </form>
-        <ul className="flex flex-col gap-2">
-          {displayedProducts.map((p) => (
-            <li key={p._id} className="border p-2 rounded flex justify-between">
-              <span>{p.name}</span>
-              <div className="flex gap-2">
-                <button className="text-blue-600" onClick={() => startEdit(p)}>
-                  <FaEdit />
-                </button>
-                <button className="text-red-600" onClick={() => deleteProduct(p._id)}>
-                  <FaTrash />
-                </button>
-              </div>
-            </li>
-          ))}
-        </ul>
-        <Pagination
-          currentPage={currentPage}
-          totalItems={allProducts.length}
-          itemsPerPage={itemsPerPage}
-          onPageChange={setCurrentPage}
-        />
+        <div className="flex flex-col gap-2">
+          <ul className="flex flex-col gap-2">
+            {displayedProducts.map((p) => (
+              <li key={p._id} className="border p-2 rounded flex justify-between">
+                <span>{p.name}</span>
+                <div className="flex gap-2">
+                  <button className="text-blue-600" onClick={() => startEdit(p)}>
+                    <FaEdit />
+                  </button>
+                  <button className="text-red-600" onClick={() => deleteProduct(p._id)}>
+                    <FaTrash />
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+          <Pagination
+            currentPage={currentPage}
+            totalItems={allProducts.length}
+            itemsPerPage={itemsPerPage}
+            onPageChange={setCurrentPage}
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- prevent numbers from defaulting to zero in admin product forms
- highlight empty required fields in admin pages
- move pagination under listing on brand/product/category pages
- fix useEffect dependency warning for brands
- ensure stable refreshBrands with useCallback

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685b0c16bc8083229b1f40c712313db0