### PR TITLE
Refactor footer layout

### DIFF
--- a/src/components/footer/Footer.jsx
+++ b/src/components/footer/Footer.jsx
@@ -1,24 +1,13 @@
 import React from "react";
-import {
-  AiOutlineLinkedin,
-  AiFillGithub,
-  AiOutlineTwitter,
-} from "react-icons/ai";
+import { AiFillInstagram } from "react-icons/ai";
 
 const Footer = () => {
   return (
-    <div className="py-5 mt-3  bg-amber-50 flex flex-wrap justify-center items-center gap-2 md:gap-10  absolute right-0 left-0 ">
-      <p>Оптика «Стиль» сделана с 💜 Sandhya </p>
+    <div className="py-5 mt-3 bg-amber-50 flex justify-between items-center gap-2 md:gap-10 absolute right-0 left-0 px-[4%] md:px-[10%] text-sm">
+      <p>© 2023. Все права занижены.</p>
       <p className="flex gap-3">
-        <a href="https://github.com/SandhyaR1007">
-          <AiFillGithub className="text-2xl text-gray-800" />
-        </a>
-        <a href="https://www.linkedin.com/in/sandhya-rajwanshi-a75b331b4/">
-          {" "}
-          <AiOutlineLinkedin className="text-2xl text-gray-800" />
-        </a>
-        <a href="https://twitter.com/SandhyaR1007">
-          <AiOutlineTwitter className="text-2xl text-gray-800" />
+        <a href="https://instagram.com" target="_blank" rel="noopener noreferrer">
+          <AiFillInstagram className="text-2xl text-gray-800" />
         </a>
       </p>
     </div>


### PR DESCRIPTION
## Summary
- simplify footer layout
- show a short rights message on the left
- keep a single Instagram link on the right

## Testing
- `npm install`
- `npm test --silent` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_685b1e0f1798832281761a87bcc80210