### PR TITLE
Improve mobile admin layout and product images

### DIFF
--- a/src/components/products/SingleProduct.jsx
+++ b/src/components/products/SingleProduct.jsx
@@ -21,7 +21,11 @@ const SingleProduct = ({ product }) => {
           navigate(`/product/${product._id}`);
         }}
       >
-        <img src={product.image} alt="" className="w-full h-full object-cover" />
+        <img
+          src={product.image}
+          alt=""
+          className="w-full h-full object-cover block"
+        />
       </div>
 
       <div className="p-3 flex flex-col justify-between gap-2 mt-2 h-1/2 xs:h-full sm:h-1/2 xs:w-2/3 w-full sm:w-full">

--- a/src/routes/AdminLayout.jsx
+++ b/src/routes/AdminLayout.jsx
@@ -1,5 +1,6 @@
 import { NavLink, Outlet } from "react-router-dom";
 import { useAdminContext } from "../contexts";
+import { useState } from "react";
 
 const links = [
   { path: "/admin", label: "Статистика" },
@@ -10,10 +11,15 @@ const links = [
 
 const AdminLayout = () => {
   const { logout } = useAdminContext();
+  const [menuOpen, setMenuOpen] = useState(false);
 
   return (
-    <div className="min-h-screen flex">
-      <aside className="w-64 bg-gray-800 text-gray-100 p-6 flex flex-col gap-4">
+    <div className="min-h-screen md:flex">
+      <aside
+        className={`fixed md:static z-20 top-0 left-0 h-full w-64 bg-gray-800 text-gray-100 p-6 flex flex-col gap-4 transform transition-transform md:translate-x-0 ${
+          menuOpen ? "translate-x-0" : "-translate-x-full"
+        }`}
+      >
         <h1 className="text-2xl font-bold mb-4">Админ панель</h1>
         <nav className="flex flex-col gap-2 flex-1">
           {links.map(({ path, label }) => (
@@ -21,6 +27,7 @@ const AdminLayout = () => {
               key={path}
               to={path}
               end={path === "/admin"}
+              onClick={() => setMenuOpen(false)}
               className={({ isActive }) =>
                 `p-2 rounded hover:bg-gray-700 ${isActive ? "bg-gray-700" : ""}`
               }
@@ -29,11 +36,23 @@ const AdminLayout = () => {
             </NavLink>
           ))}
         </nav>
-        <button onClick={logout} className="btn-secondary mt-auto">
+        <button onClick={logout} className="btn-secondary mt-auto md:block">
           Выйти
         </button>
       </aside>
+      {menuOpen && (
+        <div
+          className="fixed inset-0 bg-black/50 md:hidden"
+          onClick={() => setMenuOpen(false)}
+        ></div>
+      )}
       <main className="flex-1 p-6 bg-[--theme-color]">
+        <button
+          className="md:hidden mb-4 btn-secondary"
+          onClick={() => setMenuOpen(true)}
+        >
+          Меню
+        </button>
         <Outlet />
       </main>
     </div>


### PR DESCRIPTION
## Summary
- make admin panel layout mobile-friendly with collapsible sidebar
- ensure product card images fill their containers completely

## Testing
- `npm install --silent`
- `CI=true npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_685b2033fd8c83228666a0878c69c841